### PR TITLE
Add Dockerfile and create_fuzzy script for postgres extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM postgres:12.5-alpine
+COPY create_fuzzy.sh /docker-entrypoint-initdb.d/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A repository for the backend of leipzigtech.de.
 
 postgres for development
 ------------------------
+* build image with `docker build -t leipzigtech .`
 * adjust the path for the volume in docker-compose.yml for your environment
 * `docker-compose up -d` for starting the postgres on port 5432
 

--- a/create_fuzzy.sh
+++ b/create_fuzzy.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<EOF
+CREATE EXTENSION fuzzystrmatch SCHEMA public;
+EOF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   db:
-    image: postgres:12.5-alpine
+    image: leipzigtech
     restart: always
     container_name: le_tech_storage
     volumes:
@@ -13,6 +13,5 @@ services:
       - POSTGRES_USER=le_tech
       - POSTGRES_DB=le_tech
       - POSTGRES_PASSWORD=ddk0Re!!wIjpGAPzfa.XrQ
-
 volumes:
   postgres_data:


### PR DESCRIPTION
Description
---------------
Add a Dockerfile and create_fuzzy.sh script for postgres extension for fuzzymatcher in docker dev image.
The script is copied to container folder, where it is executed on postgres setup in container.

Usage
---------
Change to project root folder. Build docker image with command provided in README (in project root execute `docker build -t leipzigtech .`) .
After that execute `docker compose up -d` .