### PR TITLE
Add postgres env to circleci pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,10 @@ jobs:
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
       - image: circleci/postgres:12.5
+        environment:
+          POSTGRES_USER: le_tech
+          POSTGRES_DB: le_tech
+          POSTGRES_PASSWORD: ddk0Re!!wIjpGAPzfa.XrQ
 
     working_directory: ~/repo
 


### PR DESCRIPTION
Key Feature of this PR
------------------------------
Add postgres environment configuration to circleci config.yml.
Does not contain custom image with fuzzystrmatcher extension for postgres.
This has to be configured if we write tests which use fuzzy parameter in a request or something like that.

Password in env variables is just for dev purposes, prod will get a secret which is not shared in public commits