### PR TITLE
Filtering API, Sector and District Filter, Refactoring Query

### DIFF
--- a/src/main/kotlin/de/leipzigtech/ba/CompanyController.kt
+++ b/src/main/kotlin/de/leipzigtech/ba/CompanyController.kt
@@ -37,12 +37,12 @@ class CompanyController(private val comService: CompanyService) {
     }
     @CrossOrigin
     @GetMapping("/companies")
-    fun getCompanies(@RequestParam(value="name",required = false) name: String?,@RequestParam(value="case",required = false,defaultValue = "false")case:Boolean,@RequestParam(value= "orderBy",required = false,defaultValue = "name") orderBy: String,@RequestParam(value="sort",required = false,defaultValue = "ASC")sort:String): ResponseEntity<List<Company>> {
+    fun getCompanies(@RequestParam(value="name",required = false) name: String?,@RequestParam(value="case",required = false,defaultValue = "false")case:Boolean,@RequestParam(value= "orderBy",required = false,defaultValue = "name") orderBy: String,@RequestParam(value="sort",required = false,defaultValue = "ASC")sort:String,@RequestParam(value="sector",required = false,defaultValue = "")sector:String,@RequestParam(value="district",required = false,defaultValue = "")district:String): ResponseEntity<List<Company>> {
 
         if (name != null) {
-            if(!name.isBlank()) return name.let { comService.getCompaniesbyName_case(it,case) }
+            if(!name.isBlank()) return name.let { comService.getCompaniesbyName_case(it,sector,district,case) }
         }
-        return  comService.getallCompanies(sort,orderBy)
+        return  comService.getallCompanies(sort,orderBy,sector,district)
 
 
 

--- a/src/main/kotlin/de/leipzigtech/ba/repository/CompanyRepository.kt
+++ b/src/main/kotlin/de/leipzigtech/ba/repository/CompanyRepository.kt
@@ -10,18 +10,61 @@ import org.springframework.data.repository.query.Param
 @Repository
 interface CompanyRepository : JpaRepository<Company, Long> {
 
-    //fuzzy_searching
+    //Searching Querys
     @Query("SELECT *,LEVENSHTEIN(name,:name) FROM companies c Where name LIKE  CONCAT('%',:name,'%')  ORDER BY LEVENSHTEIN(c.name,:name) ASC ", nativeQuery = true)
-    fun findByName_fuzzy(@Param("name") name: kotlin.String): List<Company>
+    fun findByName(@Param("name") name: kotlin.String): List<Company>
 
-    @Query("SELECT *,LEVENSHTEIN(name,:name) FROM companies c Where name ILIKE  CONCAT('%',:name,'%')  ORDER BY LEVENSHTEIN(c.name,:name) ASC ", nativeQuery = true)
-    fun findByName_case(@Param("name") name: kotlin.String): List<Company>
 
-    fun findByNameOrderByNameAsc(name: kotlin.String):List<Company>
+    @Query("SELECT *,LEVENSHTEIN(name,:name) FROM companies c WHERE c.name like CONCAT('%', :name,'%') ORDER BY LEVENSHTEIN(c.name,:name) ASC ",nativeQuery = true)
+    fun findByNameAllIgnoreCase(@Param("name") name: String): List<Company>
+
+
+
+    // sector ,district , case = false
+    @Query("SELECT c FROM Company c WHERE lower(c.name) like lower(concat('%', :name,'%'))AND (c.sector IN (:sector)) AND (c.district IN (:district)) ")     // 2. Spring JPA In cause using @Query
+    fun findByNameAllIgnoreCaseSectorInAndDistrictIn(@Param("name") name: String,@Param("sector") sector: List<String>,@Param("district") district: List<String>): List<Company>
+    // sector , district , case = true
+    @Query("SELECT  c FROM Company c Where c.name LIKE  CONCAT('%',:name,'%') AND (c.sector IN (:sector)) AND (c.district IN (:district)) ")
+    fun findByNameSectorInAndDistrictIn(@Param("name") name: kotlin.String,@Param("sector")sector: List<String>,@Param("district")district: List<String>): List<Company>
+    //only Sector, district empty , case=true
+    fun findAllByNameContainingAndSectorIn(name: kotlin.String,sector: List<String>):List<Company>
+    //only Sector, district empty , case=false
+    fun findAllByNameContainingIgnoreCaseAndSectorIn(name: kotlin.String,sector: List<String>):List<Company>
+
+    //only district , sector empty, case = false
+    fun findAllByNameContainingIgnoreCaseAndDistrictIn(name: kotlin.String,district: List<String>):List<Company>
+    //only district , sector empty, case = true
+    fun findAllByNameContainingAndDistrictIn(name: kotlin.String,district: List<String>):List<Company>
+
+    // Get Companies without Name
+    //only sector , district empty, ASC
+    @Query("SELECT c FROM Company c WHERE  (c.sector IN (:sector)) order by :orderBy ASC ")
+    fun findAllBySectorInASC(@Param("sector") sector: List<String>, @Param("orderBy")orderBy:String): List<Company>
+    //only sector , district empty, DESC
+    @Query("SELECT c FROM Company c WHERE  (c.sector IN (:sector)) order by :orderBy DESC ")
+    fun findAllBySectorInDesc(@Param("sector") sector: List<String>, @Param("orderBy")orderBy:String): List<Company>
+
+    //only district , sector empty, ASC
+    @Query("SELECT c FROM Company c WHERE  (c.district IN (:district)) order by :orderBy ASC ")
+    fun findAllByDistrictInOrderByASC(@Param("district") district: List<String>, @Param("orderBy")orderBy:String): List<Company>
+    //only district , sector empty, DESC
+    @Query("SELECT c FROM Company c WHERE  (c.district IN (:district)) order by :orderBy DESC ")
+    fun findAllByDistrictInOrderByDESC(@Param("district") district: List<String>, @Param("orderBy")orderBy:String): List<Company>
+
+    // district , sector , ASC
+    @Query("SELECT c FROM Company c WHERE (c.sector IN (:sector)) AND (c.district IN (:district)) order by :orderBy ASC ")
+    fun findAllByDistrictInAndSectorInOrderByASC(@Param("sector") sector: List<String>,@Param("district") district: List<String>, @Param("orderBy")orderBy:String): List<Company>
+
+    // district , sector , DESC
+    @Query("SELECT c FROM Company c WHERE (c.sector IN (:sector)) AND (c.district IN (:district)) order by :orderBy DESC ")
+    fun findAllByDistrictInAndSectorInOrderByDESC(@Param("sector") sector: List<String>,@Param("district") district: List<String>, @Param("orderBy")orderBy:String): List<Company>
+
+    // Ref-API
     @Query("SELECT * From companies c ",nativeQuery = true)
     fun getAllRef():List<Company>
-    fun findByNameOrderByNameDesc(name: kotlin.String):List<Company>
 
+
+    //Statistic
     @Query("SELECT sector ,COUNT(*) From companies c Group by sector",nativeQuery = true)
     fun countBySector():List<String>
     @Query("SELECT district ,COUNT(*) From companies c Group by district",nativeQuery = true)


### PR DESCRIPTION
# Key features

- Filter options for district and sector.
- new database query's


## **several parameters are to be searched** 

- new API params: **sector** , **district**

- multiple **sectors**  and **districts** can be passed, separated by comma

**Filteroption**:

with **name** and **without name** Parameter
- sector empty ,district empty ->normal request
- sector empty, district= ...,...  -> filtering by district
- sector= ...,..., district empty  -> filtering by sector
- sector=...,...   district= ....,...  -> filtering by sector and district 

**Example:**

GET /companies?name=GmbH&**sector**=it-beratung,edv&**district**=zentrum,südvorstadt

Entries with (it-beratung OR edv )**AND** ( zentrum OR südvorstadt)
