### PR TITLE
Add profiles to application.yml to address issues with circleci build

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,36 @@ logging:
     org:
       springframework: ERROR
 spring:
+  profiles:
+    active: dev
+
+---
+spring:
+  profiles: dev
+  datasource:
+    password: ddk0Re!!wIjpGAPzfa.XrQ
+    platform: postgres
+    url: jdbc:postgresql://localhost:5432/le_tech
+    username: le_tech
+  jpa:
+    generate-ddl: true
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+      javax:
+        persistence:
+          schema-generation:
+            scripts:
+              action: create
+              create-source: metadata
+              create-target: ./src/main/resources/db/migration/create.sql
+
+---
+spring:
+  profiles: compose
   datasource:
     password: ddk0Re!!wIjpGAPzfa.XrQ
     platform: postgres


### PR DESCRIPTION
Added dev profile to application.yml to differentiate compose build and build for development with postgres on localhost instead of container addressed by db in compose mesh.
Profile dev is default for non-failing circleci.
